### PR TITLE
graphex graph select bugfixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,18 @@
-repl: hpack
+repl: graphex.cabal
 	cabal repl
 .PHONY: repl
 
-exe-repl: hpack
+exe-repl: graphex.cabal
 	cabal repl exe:graphex
 .PHONY: exe-repl
 
-hpack: package.yaml
+graphex.cabal: package.yaml
 	hpack
 
-install: hpack
+install: graphex.cabal
 	cabal install exe:graphex --overwrite-policy=always
+.PHONY: install
+
+test: graphex.cabal
+	cabal test
+.PHONY: test

--- a/package.yaml
+++ b/package.yaml
@@ -53,6 +53,7 @@ default-extensions:
   - BangPatterns
   - ImportQualifiedPost
   - LambdaCase
+  - MultiWayIf
 
 executables:
   graphex:

--- a/src/Graphex.hs
+++ b/src/Graphex.hs
@@ -56,7 +56,10 @@ rankings g@(Graph m) = Map.fromList $ parMap rdeepseq (\k -> (k, length $ allDep
 
 -- | Restrict a graph to only the modules that reference a given module.
 restrictTo :: Graph -> Text -> Graph
-restrictTo g@(Graph m) k = Graph . flip Map.mapMaybeWithKey m $ \k' v -> if k' == k then Just v else nonNullSet (Set.intersection keep v)
+restrictTo g@(Graph m) k = Graph . flip Map.mapMaybeWithKey m $ \k' v ->
+  if | k' == k -> Just v
+     | Set.notMember k' keep -> Nothing
+     | otherwise -> nonNullSet (Set.intersection keep v)
     where
         keep = allDepsOn g k
         nonNullSet v = if Set.null v then Nothing else Just v

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -98,6 +98,12 @@ prop_ranking (GraphWithKey k g) = length (allDepsOn g k) == rankings g Map.! k
 prop_restrictedGraphHasSameDeps :: GraphWithKey -> Bool
 prop_restrictedGraphHasSameDeps (GraphWithKey k g) = allDepsOn g k == allDepsOn (restrictTo g k) k
 
+prop_restrictedNodesShouldBeDeps :: GraphWithKey -> Bool
+prop_restrictedNodesShouldBeDeps (GraphWithKey k g) =
+  let edges = Map.toList (unGraph $ restrictTo g k)
+      validNodes = Set.insert k $ allDepsOn g k
+  in all (\(k, vs) -> Set.member k validNodes && all (flip Set.member validNodes) vs) edges
+
 prop_importExport :: Graph -> Property
 prop_importExport g =
     counterexample ("exported: " <> show exported <> "\nimported: " <> show imported) $
@@ -117,6 +123,7 @@ tests = [
     testProperty "all deps contains direct deps" prop_allDepsContainsSelfDeps,
     testProperty "ranking is the same size as all deps" prop_ranking,
     testProperty "restricted input has the same deps as the original" prop_restrictedGraphHasSameDeps,
+    testProperty "restricted input should only contain nodes that are deps of the original" prop_restrictedNodesShouldBeDeps,
     testProperty "can round trip import/export of graph" prop_importExport
     ]
 

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -98,11 +98,13 @@ prop_ranking (GraphWithKey k g) = length (allDepsOn g k) == rankings g Map.! k
 prop_restrictedGraphHasSameDeps :: GraphWithKey -> Bool
 prop_restrictedGraphHasSameDeps (GraphWithKey k g) = allDepsOn g k == allDepsOn (restrictTo g k) k
 
-prop_restrictedNodesShouldBeDeps :: GraphWithKey -> Bool
+prop_restrictedNodesShouldBeDeps :: GraphWithKey -> Property
 prop_restrictedNodesShouldBeDeps (GraphWithKey k g) =
-  let edges = Map.toList (unGraph $ restrictTo g k)
+  let restricted = restrictTo g k
+      edges = Map.toList (unGraph restricted)
       validNodes = Set.insert k $ allDepsOn g k
-  in all (\(k, vs) -> Set.member k validNodes && all (flip Set.member validNodes) vs) edges
+  in counterexample ("restricted: " <> show restricted) $
+     all (\(k, vs) -> Set.member k validNodes && all (flip Set.member validNodes) vs) edges
 
 prop_importExport :: Graph -> Property
 prop_importExport g =


### PR DESCRIPTION
I found two small issues while running `graphex graph select` on a real Haskell codebase:
1. It kept things around that it shouldn't have.
2. `-r` would not just select reverse deps but also reverse the output graph. I don't think this is a user wants when they ask to `select` reverse since they're pruning their original graph.

I wrote a property test for (1) and found this minimal example:
```
  restricted input should only contain nodes that are deps of the original: FAIL
    *** Failed! Falsified (after 1 test and 4 shrinks):
    GraphWithKey "function" "foo" -> [], "function" -> ["foo"], "z" -> ["foo"], 
    restricted: "function" -> ["foo"], "z" -> ["foo"],
```

It preserves the `"function -> ["foo"]` edge because `"foo" is a dependency of `"z"` even though that part of the graph is not connected to `"z"`.

Adding an extra check that the parent is also a dep of the node we are selecting fixes this.