### PR TITLE
Discover more modules (exes, sub-libraries, test-suites)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,7 @@ test: graphex.cabal
 fmt:
 	fd .hs src --exec stylish-haskell -i
 	fd .hs test --exec stylish-haskell -i
+	fd .hs app --exec stylish-haskell -i
 .PHONY: fmt
 
 graph.json:

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,7 @@ test: graphex.cabal
 fmt:
 	fd .hs --exec stylish-haskell -i
 .PHONY: fmt
+
+graph.json:
+	cabal run -v0 exe:graphex -- cabal > graph.json
+.PHONY: graph.json

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,10 @@ exe-repl: graphex.cabal
 	cabal repl exe:graphex
 .PHONY: exe-repl
 
+test-repl: graphex.cabal
+	cabal repl tests
+.PHONY: test-repl
+
 graphex.cabal: package.yaml
 	hpack
 
@@ -14,7 +18,7 @@ install: graphex.cabal
 .PHONY: install
 
 test: graphex.cabal
-	cabal test
+	cabal test --test-show-details=streaming
 .PHONY: test
 
 fmt:

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -5,19 +5,22 @@ import           Control.Applicative  ((<|>))
 import           Data.Aeson           (encode)
 import           Data.Bool            (bool)
 import qualified Data.ByteString.Lazy as BL
-import qualified Data.Set as Set
 import qualified Data.Csv             as CSV
 import           Data.Foldable
 import           Data.List.NonEmpty   (NonEmpty (..))
 import qualified Data.List.NonEmpty   as NE
 import           Data.Maybe           (fromMaybe)
+import qualified Data.Set             as Set
 import           Data.Text            (Text)
 import qualified Data.Text            as T
 import qualified Data.Text.IO         as TIO
 import           Data.Tree.View       (drawTree)
-import           Options.Applicative  (Parser, argument, command, customExecParser, fullDesc, help, helper, hsubparser,
-                                       info, long, metavar, prefs, progDesc, short, showDefault, showHelpOnError, some,
-                                       str, strOption, switch, value, (<**>))
+import           Options.Applicative  (Parser, argument, command,
+                                       customExecParser, fullDesc, help, helper,
+                                       hsubparser, info, long, metavar, prefs,
+                                       progDesc, short, showDefault,
+                                       showHelpOnError, some, str, strOption,
+                                       switch, value, (<**>))
 
 import           Graphex
 import           Graphex.Cabal
@@ -53,8 +56,8 @@ options = hsubparser $ fold
   ]
 
 data CabalOptions = CabalOptions
-  { optDiscoverExes :: Bool
-  , optDiscoverTests :: Bool
+  { optDiscoverExes    :: Bool
+  , optDiscoverTests   :: Bool
   , optIncludeExternal :: Bool
   } deriving stock Show
 

--- a/src/Graphex/Cabal.hs
+++ b/src/Graphex/Cabal.hs
@@ -86,6 +86,15 @@ discoverCabalModules cabalFile = do
 
   filterM (doesFileExist . (.path)) candidateModules
 
+discoverCabalPackageDescription :: IO PackageDescription
+discoverCabalPackageDescription = do
+  fs <- getDirectoryContents "." -- XXX
+  let cabalFile = case filter ((".cabal" ==) . takeExtension) fs of
+        path : _ -> path
+        _ -> error "No cabal file found"
+  gpd <- readGenericPackageDescription silent cabalFile
+  pure $ flattenPackageDescription gpd
+
 discoverCabalModuleGraph :: IO ModuleGraph
 discoverCabalModuleGraph = do
   fs <- getDirectoryContents "." -- XXX

--- a/src/Graphex/Core.hs
+++ b/src/Graphex/Core.hs
@@ -6,7 +6,7 @@ import           Data.Map        (Map)
 import qualified Data.Map.Strict as Map
 import           Data.Set        (Set)
 import qualified Data.Set        as Set
-import           Data.String     (IsString)
+import           Data.String     (IsString (..))
 import           Data.Text       (Text)
 
 data Graph a = Graph {
@@ -46,11 +46,14 @@ newtype ModuleName = ModuleName { unModuleName :: Text }
 data ModulePath = ModuleNoFile | ModuleFile FilePath
   deriving stock (Eq, Ord, Show)
 
+instance IsString ModulePath where
+  fromString = ModuleFile
+
 data Module = Module
   { name :: ModuleName
   , path :: ModulePath
   }
-  deriving stock (Show, Eq)
+  deriving stock (Show, Eq, Ord)
 
 type ModuleGraph = Graph ModuleName
 

--- a/src/Graphex/Core.hs
+++ b/src/Graphex/Core.hs
@@ -43,9 +43,12 @@ newtype ModuleName = ModuleName { unModuleName :: Text }
   deriving newtype (Eq, Ord, IsString)
   deriving stock (Show)
 
+data ModulePath = ModuleNoFile | ModuleFile FilePath
+  deriving stock (Eq, Ord, Show)
+
 data Module = Module
   { name :: ModuleName
-  , path :: FilePath
+  , path :: ModulePath
   }
   deriving stock (Show, Eq)
 

--- a/test/CabalSpec.hs
+++ b/test/CabalSpec.hs
@@ -2,6 +2,7 @@
 module CabalSpec where
 
 import           Data.Foldable    (fold)
+import           Data.List        (sort)
 import qualified Data.Map.Strict  as Map
 import           Data.Maybe       (isJust)
 import qualified Data.Set         as Set
@@ -14,19 +15,55 @@ import           Graphex.Core
 
 import           TestInstances    ()
 
-myModules :: [Module]
-myModules = [Module "Graphex" "src/Graphex.hs",
-             Module "Graphex.Cabal" "src/Graphex/Cabal.hs",
-             Module "Graphex.Core" "src/Graphex/Core.hs",
-             Module "Graphex.CSV" "src/Graphex/CSV.hs",
-             Module "Graphex.LookingGlass" "src/Graphex/LookingGlass.hs",
-             Module "Graphex.Parser" "src/Graphex/Parser.hs",
-             Module "Graphex.Search" "src/Graphex/Search.hs"]
+libModules :: [Module]
+libModules =
+  [ Module "Graphex" "src/Graphex.hs"
+  , Module "Graphex.Cabal" "src/Graphex/Cabal.hs"
+  , Module "Graphex.Core" "src/Graphex/Core.hs"
+  , Module "Graphex.CSV" "src/Graphex/CSV.hs"
+  , Module "Graphex.LookingGlass" "src/Graphex/LookingGlass.hs"
+  , Module "Graphex.Parser" "src/Graphex/Parser.hs"
+  , Module "Graphex.Search" "src/Graphex/Search.hs"
+  ]
 
-unit_myCabalModules :: IO ()
-unit_myCabalModules = assertEqual "" myModules =<< discoverCabalModules "graphex.cabal"
+testModules :: [Module]
+testModules =
+  [ Module "CabalSpec" "test/CabalSpec.hs"
+  , Module "ImportParserSpec" "test/ImportParserSpec.hs"
+  , Module "Paths_graphex" ModuleNoFile
+  , Module "Spec"  "test/Spec.hs"
+  , Module "TestInstances"  "test/TestInstances.hs"
+  ]
+
+exeModules :: [Module]
+exeModules =
+  [ Module "Paths_graphex" ModuleNoFile
+  , Module "graphex-Main" "app/Main.hs"
+  ]
+
+
+mkDiscoverCabalModulesUnit :: [Module] -> CabalDiscoverOpts -> IO ()
+mkDiscoverCabalModulesUnit (sort -> mods) opts = assertEqual "" mods . sort =<< discoverCabalModules opts "graphex.cabal"
+
+unit_libCabalModules :: IO ()
+unit_libCabalModules = mkDiscoverCabalModulesUnit libModules CabalDiscoverOpts
+  { toDiscover = Set.singleton CabalLibraries
+  , includeExternal = False
+  }
+
+unit_exeCabalModules :: IO ()
+unit_exeCabalModules = mkDiscoverCabalModulesUnit exeModules CabalDiscoverOpts
+  { toDiscover = Set.singleton CabalExecutables
+  , includeExternal = False
+  }
+
+unit_testCabalModules :: IO ()
+unit_testCabalModules = mkDiscoverCabalModulesUnit testModules CabalDiscoverOpts
+  { toDiscover = Set.singleton CabalTests
+  , includeExternal = False
+  }
 
 unit_discoverModules :: IO ()
 unit_discoverModules = do
-    g <- discoverCabalModuleGraph
+    g <- discoverCabalModuleGraph CabalDiscoverOpts{toDiscover = Set.singleton CabalLibraries, includeExternal = False}
     assertBool (show g) . isJust $ why g "Graphex.Parser" "Graphex.Core"


### PR DESCRIPTION
exe `Main` modules are prefixed with the exe name, fixing this old `graphmod` bug: https://github.com/yav/graphmod/issues/28


Fixes https://github.com/dustin/graphex/issues/8