### PR TITLE
Fix `why` now that we have standardized on an arrow direction

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -96,7 +96,7 @@ main = customExecParser (prefs showHelpOnError) opts >>= \case
             $ graphToTree fromModule
             $ allPathsTo graph fromModule toModule
           else
-            let explainer = if optReverse then " imported by " else " imports "
+            let explainer = if optReverse then " imports " else " imported by "
                 mkWhy rev = uncurry (why graph) $ if rev then (toModule, fromModule) else (fromModule, toModule)
                 renderWhy rev = NE.zipWith (<>) ("" :| repeat explainer) <$> mkWhy rev
             in printStrs $ fromMaybe (pure "No path found") $ renderWhy True <|> renderWhy False

--- a/package.yaml
+++ b/package.yaml
@@ -83,3 +83,5 @@ tests:
     - tasty-quickcheck
     - tasty-discover
     - checkers
+    build-tools:
+    - tasty-discover


### PR DESCRIPTION
https://github.com/dustin/graphex/commit/45337fef1505203f5d7976b3e7ce70fb61c7cf80 found that graphex was inconsistent in its arrow direction.

Now we have standardized on `X -> Y` meaning `X imports Y`. `why` was doing the opposite (because it worked with the previous wrong code). So this fixes that.

I don't think standardizing on one direction or the other matters much. I like that the arrow corresponds to importing, but also the arrow direction we chose goes "against the dataflow" if you think of data flowing to `Main`.

I think the arrow flipping also flips how to use the CLI generally. I noticed I had to reverse my usage:

- `all` gives you all transitive imports a module is doing.
- `-r all` gives you all things that transitively import a module.
- `deps` is the same as `all` but direct.
- `why` is direction agnostic.

I'll probably write some quick markdown docs with a few example modules & example CLI invocations.