### PR TITLE
More granular & configurable Cabal discovery

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,5 +28,5 @@ fmt:
 .PHONY: fmt
 
 graph.json:
-	cabal run -v0 exe:graphex -- cabal > graph.json
+	cabal run -v0 exe:graphex -- cabal ${args} > graph.json
 .PHONY: graph.json

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE ApplicativeDo #-}
 module Main where
 
+
 import           Control.Applicative  ((<|>))
 import           Data.Aeson           (encode)
 import           Data.Bool            (bool)
@@ -10,7 +11,6 @@ import           Data.Foldable
 import           Data.List.NonEmpty   (NonEmpty (..))
 import qualified Data.List.NonEmpty   as NE
 import           Data.Maybe           (fromMaybe)
-import qualified Data.Set             as Set
 import           Data.Text            (Text)
 import qualified Data.Text            as T
 import qualified Data.Text.IO         as TIO
@@ -23,10 +23,9 @@ import           Options.Applicative  (Parser, argument, command,
                                        switch, value, (<**>))
 
 import           Graphex
-import           Graphex.Cabal
 import           Graphex.Core
 import qualified Graphex.CSV
-import           Graphex.LookingGlass
+import           Main.Cabal
 
 data Command
     = DirectDepsOn Text
@@ -54,19 +53,6 @@ options = hsubparser $ fold
   [ command "graph" (info (GraphCmd <$> graphOptions) (progDesc "Graph operations"))
   , command "cabal" (info (CabalCmd <$> cabalOptions) (progDesc "Cabal operations"))
   ]
-
-data CabalOptions = CabalOptions
-  { optDiscoverExes    :: Bool
-  , optDiscoverTests   :: Bool
-  , optIncludeExternal :: Bool
-  } deriving stock Show
-
-cabalOptions :: Parser CabalOptions
-cabalOptions = do
-  optDiscoverExes <- switch (long "discover-exes" <> help "Discover exe import dependencies")
-  optDiscoverTests <- switch (long "discover-tests" <> help "Discover test import dependencies")
-  optIncludeExternal <- switch (long "include-external" <> help "Include external import dependencies")
-  pure CabalOptions{..}
 
 graphOptions :: Parser GraphOptions
 graphOptions = GraphOptions
@@ -120,15 +106,6 @@ main = customExecParser (prefs showHelpOnError) opts >>= \case
         FindLongest      -> printStrs $ longest graph
         Select m         -> BL.putStr $ encode (graphToDep (handleReverse (setAttribute m "note" "start" $ restrictTo graph (allDepsOn graph m))))
         ToCSV noHeader   -> BL.putStr $ (if noHeader then CSV.encode else CSV.encodeDefaultOrderedByName) $ Graphex.CSV.toEdges graph
-  CabalCmd CabalOptions{..} -> do
-    mg <- discoverCabalModuleGraph CabalDiscoverOpts
-      { toDiscover = mconcat
-          [ Set.singleton CabalLibraries
-          , bool mempty (Set.singleton CabalExecutables) optDiscoverExes
-          , bool mempty (Set.singleton CabalTests) optDiscoverTests
-          ]
-      , includeExternal = optIncludeExternal
-      }
-    BL.putStr $ encode $ toLookingGlass "Internal Package Dependencies" mempty mg
+  CabalCmd cabalOpts -> runCabal cabalOpts
   where
     opts = info (options <**> helper) ( fullDesc <> progDesc "Graph CLI tool.")

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -39,7 +39,7 @@ data Command
     deriving stock Show
 
 
-data Options = GraphCmd GraphOptions | CabalCmd CabalOptions
+data Options = GraphCmd GraphOptions | CabalCmd CabalOptions| CabalCmd2 CabalOptions2
   deriving stock Show
 
 data GraphOptions = GraphOptions {
@@ -52,6 +52,7 @@ options :: Parser Options
 options = hsubparser $ fold
   [ command "graph" (info (GraphCmd <$> graphOptions) (progDesc "Graph operations"))
   , command "cabal" (info (CabalCmd <$> cabalOptions) (progDesc "Cabal operations"))
+  , command "cabal2" (info (CabalCmd2 <$> cabalOptions2) (progDesc "Cabal operations"))
   ]
 
 graphOptions :: Parser GraphOptions
@@ -108,7 +109,8 @@ main = customExecParser (prefs showHelpOnError) opts >>= \case
         FindLongest      -> printStrs $ longest graph
         Select m         -> BL.putStr $ encode (graphToDep (handleReverse (setAttribute m "note" "start" $ restrictTo graph (allDepsOn graph m))))
         ToCSV noHeader   -> BL.putStr $ (if noHeader then CSV.encode else CSV.encodeDefaultOrderedByName) $ Graphex.CSV.toEdges graph
-        CabalCmd cabalOpts -> runCabal cabalOpts
         Cat files        -> BL.putStr . encode . graphToDep . fold =<< traverse getInput files
+  CabalCmd cabalOpts -> runCabal cabalOpts
+  CabalCmd2 cabalOpts -> runCabal2 cabalOpts
   where
     opts = info (options <**> helper) ( fullDesc <> progDesc "Graph CLI tool.")

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -39,7 +39,7 @@ data Command
     deriving stock Show
 
 
-data Options = GraphCmd GraphOptions | CabalCmd CabalOptions| CabalCmd2 CabalOptions2
+data Options = GraphCmd GraphOptions | CabalCmd CabalOptions
   deriving stock Show
 
 data GraphOptions = GraphOptions {
@@ -52,7 +52,6 @@ options :: Parser Options
 options = hsubparser $ fold
   [ command "graph" (info (GraphCmd <$> graphOptions) (progDesc "Graph operations"))
   , command "cabal" (info (CabalCmd <$> cabalOptions) (progDesc "Cabal operations"))
-  , command "cabal2" (info (CabalCmd2 <$> cabalOptions2) (progDesc "Cabal operations"))
   ]
 
 graphOptions :: Parser GraphOptions
@@ -111,6 +110,5 @@ main = customExecParser (prefs showHelpOnError) opts >>= \case
         ToCSV noHeader   -> BL.putStr $ (if noHeader then CSV.encode else CSV.encodeDefaultOrderedByName) $ Graphex.CSV.toEdges graph
         Cat files        -> BL.putStr . encode . graphToDep . fold =<< traverse getInput files
   CabalCmd cabalOpts -> runCabal cabalOpts
-  CabalCmd2 cabalOpts -> runCabal2 cabalOpts
   where
     opts = info (options <**> helper) ( fullDesc <> progDesc "Graph CLI tool.")

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE ApplicativeDo #-}
 module Main where
 
-
 import           Control.Applicative  ((<|>))
 import           Data.Aeson           (encode)
 import           Data.Bool            (bool)

--- a/app/Main/Cabal.hs
+++ b/app/Main/Cabal.hs
@@ -24,6 +24,32 @@ cabalOptions = do
   optIncludeExternal <- switch (long "include-external" <> help "Include external import dependencies")
   pure CabalOptions{..}
 
+data CabalOptions2 = CabalOptions2
+  { optToDiscover :: [CabalDiscoverType]
+  , optIncludeExternal2 :: Bool
+  } deriving stock Show
+
+justWhen :: a -> Bool -> Maybe a
+justWhen a True = Just a
+justWhen _ False = Nothing
+
+cabalOptions2 :: Parser CabalOptions2
+cabalOptions2 = do
+  optToDiscover <- many $ asum
+    [ flag' (CabalDiscoverAll CabalLibrary) (long "discover-all-libs" <> help "Discover all library import dependencies")
+    , flag' (CabalDiscoverAll CabalExecutable) (long "discover-all-exes" <> help "Discover all executable import dependencies")
+    , flag' (CabalDiscoverAll CabalTests) (long "discover-all-tests" <> help "Discover all test import dependencies")
+    , flag' (CabalDontDiscoverAll CabalLibrary) (long "no-discover-all-libs" <> help "Discover no library import dependencies")
+    , flag' (CabalDontDiscoverAll CabalExecutable) (long "no-discover-all-exes" <> help "Discover no executable import dependencies")
+    , flag' (CabalDontDiscoverAll CabalTests) (long "no-discover-all-exes" <> help "Discover no test import dependencies")
+    -- TODO: Do the same but for granular (use strOption)
+    ]
+  optIncludeExternal2 <- switch (long "include-external" <> help "Include external import dependencies")
+  pure CabalOptions2{..}
+
+runCabal2 :: CabalOptions2 -> IO ()
+runCabal2 = print
+
 runCabal :: CabalOptions -> IO ()
 runCabal CabalOptions{..} = do
   let discoverOpts = CabalDiscoverOpts

--- a/app/Main/Cabal.hs
+++ b/app/Main/Cabal.hs
@@ -12,30 +12,16 @@ import           Graphex.Cabal
 import           Graphex.LookingGlass
 
 data CabalOptions = CabalOptions
-  { optDiscoverExes    :: Bool
-  , optDiscoverTests   :: Bool
+  { optToDiscover      :: [CabalDiscoverType]
   , optIncludeExternal :: Bool
-  } deriving stock Show
-
--- TODO: Do a left-to-right-preserving discover opts parser
-cabalOptions :: Parser CabalOptions
-cabalOptions = do
-  optDiscoverExes <- switch (long "discover-exes" <> help "Discover exe import dependencies")
-  optDiscoverTests <- switch (long "discover-tests" <> help "Discover test import dependencies")
-  optIncludeExternal <- switch (long "include-external" <> help "Include external import dependencies")
-  pure CabalOptions{..}
-
-data CabalOptions2 = CabalOptions2
-  { optToDiscover       :: [CabalDiscoverType]
-  , optIncludeExternal2 :: Bool
   } deriving stock Show
 
 justWhen :: a -> Bool -> Maybe a
 justWhen a True  = Just a
 justWhen _ False = Nothing
 
-cabalOptions2 :: Parser CabalOptions2
-cabalOptions2 = do
+cabalOptions :: Parser CabalOptions
+cabalOptions = do
   optToDiscover <- fmap mconcat $ many $ asum
     [ flag' [CabalDiscoverAll CabalLibrary, CabalDiscoverAll CabalExecutable, CabalDiscoverAll CabalTests] (long "discover-all" <> help "Discover all import dependencies")
     , flag' (pure $ CabalDiscoverAll CabalLibrary) (long "discover-all-libs" <> help "Discover all library import dependencies")
@@ -53,25 +39,13 @@ cabalOptions2 = do
     , pure . CabalDiscover . CabalTestsUnit <$> strOption (long "discover-test" <> help "Discover specified test import dependencies")
     , pure . CabalDontDiscover . CabalTestsUnit <$> strOption (long "no-discover-test" <> help "Don't discover specified test import dependencies")
     ]
-  optIncludeExternal2 <- switch (long "include-external" <> help "Include external import dependencies")
-  pure CabalOptions2{..}
-
-runCabal2 :: CabalOptions2 -> IO ()
-runCabal2 CabalOptions2{..} = do
-  let discoverOpts = CabalDiscoverOpts
-        { toDiscover = fromMaybe (pure $ CabalDiscover (CabalLibraryUnit Nothing)) $ nonEmpty optToDiscover
-        , includeExternal = optIncludeExternal2
-        }
-  mg <- discoverCabalModuleGraph discoverOpts
-  BL.putStr $ encode $ toLookingGlass "Internal Package Dependencies" mempty mg
+  optIncludeExternal <- switch (long "include-external" <> help "Include external import dependencies")
+  pure CabalOptions{..}
 
 runCabal :: CabalOptions -> IO ()
 runCabal CabalOptions{..} = do
   let discoverOpts = CabalDiscoverOpts
-        { toDiscover = CabalDiscoverAll CabalLibrary :| mconcat
-          [ bool mempty [CabalDiscoverAll CabalExecutable] optDiscoverExes
-          , bool mempty [CabalDiscoverAll CabalTests] optDiscoverTests
-          ]
+        { toDiscover = fromMaybe (pure $ CabalDiscover (CabalLibraryUnit Nothing)) $ nonEmpty optToDiscover
         , includeExternal = optIncludeExternal
         }
   mg <- discoverCabalModuleGraph discoverOpts

--- a/app/Main/Cabal.hs
+++ b/app/Main/Cabal.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE ApplicativeDo #-}
+module Main.Cabal where
+
+import           Data.Aeson           (encode)
+import           Data.Bool            (bool)
+import qualified Data.ByteString.Lazy as BL
+import           Data.List.NonEmpty   (NonEmpty (..))
+import           Options.Applicative
+
+import           Graphex.Cabal
+import           Graphex.LookingGlass
+
+data CabalOptions = CabalOptions
+  { optDiscoverExes    :: Bool
+  , optDiscoverTests   :: Bool
+  , optIncludeExternal :: Bool
+  } deriving stock Show
+
+-- TODO: Do a left-to-right-preserving discover opts parser
+cabalOptions :: Parser CabalOptions
+cabalOptions = do
+  optDiscoverExes <- switch (long "discover-exes" <> help "Discover exe import dependencies")
+  optDiscoverTests <- switch (long "discover-tests" <> help "Discover test import dependencies")
+  optIncludeExternal <- switch (long "include-external" <> help "Include external import dependencies")
+  pure CabalOptions{..}
+
+runCabal :: CabalOptions -> IO ()
+runCabal CabalOptions{..} = do
+  let discoverOpts = CabalDiscoverOpts
+        { toDiscover = CabalDiscoverAll CabalLibrary :| mconcat
+          [ bool mempty [CabalDiscoverAll CabalExecutable] optDiscoverExes
+          , bool mempty [CabalDiscoverAll CabalTests] optDiscoverTests
+          ]
+        , includeExternal = optIncludeExternal
+        }
+  mg <- discoverCabalModuleGraph discoverOpts
+  BL.putStr $ encode $ toLookingGlass "Internal Package Dependencies" mempty mg

--- a/app/Main/Cabal.hs
+++ b/app/Main/Cabal.hs
@@ -4,7 +4,8 @@ module Main.Cabal where
 import           Data.Aeson           (encode)
 import           Data.Bool            (bool)
 import qualified Data.ByteString.Lazy as BL
-import           Data.List.NonEmpty   (NonEmpty (..))
+import           Data.List.NonEmpty   (NonEmpty (..), nonEmpty)
+import Data.Maybe (fromMaybe)
 import           Options.Applicative
 
 import           Graphex.Cabal
@@ -35,20 +36,34 @@ justWhen _ False = Nothing
 
 cabalOptions2 :: Parser CabalOptions2
 cabalOptions2 = do
-  optToDiscover <- many $ asum
-    [ flag' (CabalDiscoverAll CabalLibrary) (long "discover-all-libs" <> help "Discover all library import dependencies")
-    , flag' (CabalDiscoverAll CabalExecutable) (long "discover-all-exes" <> help "Discover all executable import dependencies")
-    , flag' (CabalDiscoverAll CabalTests) (long "discover-all-tests" <> help "Discover all test import dependencies")
-    , flag' (CabalDontDiscoverAll CabalLibrary) (long "no-discover-all-libs" <> help "Discover no library import dependencies")
-    , flag' (CabalDontDiscoverAll CabalExecutable) (long "no-discover-all-exes" <> help "Discover no executable import dependencies")
-    , flag' (CabalDontDiscoverAll CabalTests) (long "no-discover-all-exes" <> help "Discover no test import dependencies")
-    -- TODO: Do the same but for granular (use strOption)
+  optToDiscover <- fmap mconcat $ many $ asum
+    [ flag' [CabalDiscoverAll CabalLibrary, CabalDiscoverAll CabalExecutable, CabalDiscoverAll CabalTests] (long "discover-all" <> help "Discover all import dependencies")
+    , flag' (pure $ CabalDiscoverAll CabalLibrary) (long "discover-all-libs" <> help "Discover all library import dependencies")
+    , flag' (pure $ CabalDiscoverAll CabalExecutable) (long "discover-all-exes" <> help "Discover all executable import dependencies")
+    , flag' (pure $ CabalDiscoverAll CabalTests) (long "discover-all-tests" <> help "Discover all test import dependencies")
+    , flag' (pure $ CabalDontDiscoverAll CabalLibrary) (long "no-discover-all-libs" <> help "Discover no library import dependencies")
+    , flag' (pure $ CabalDontDiscoverAll CabalExecutable) (long "no-discover-all-exes" <> help "Discover no executable import dependencies")
+    , flag' (pure $ CabalDontDiscoverAll CabalTests) (long "no-discover-all-exes" <> help "Discover no test import dependencies")
+    , flag' (pure $ CabalDiscover (CabalLibraryUnit Nothing)) (long "discover-lib" <> help "Discover the default library import dependencies")
+    , flag' (pure $ CabalDontDiscover (CabalLibraryUnit Nothing)) (long "no-discover-lib" <> help "Don't discover the default library import dependencies")
+    , pure . CabalDiscover . CabalLibraryUnit . Just <$> strOption (long "discover-sublib" <> help "Discover specified sublibrary import dependencies")
+    , pure . CabalDontDiscover . CabalLibraryUnit . Just <$> strOption (long "no-discover-sublib" <> help "Don't discover specified sublibrary import dependencies")
+    , pure . CabalDiscover . CabalExecutableUnit <$> strOption (long "discover-exe" <> help "Discover specified executable import dependencies")
+    , pure . CabalDontDiscover . CabalExecutableUnit <$> strOption (long "no-discover-exe" <> help "Don't discover specified executable import dependencies")
+    , pure . CabalDiscover . CabalTestsUnit <$> strOption (long "discover-test" <> help "Discover specified test import dependencies")
+    , pure . CabalDontDiscover . CabalTestsUnit <$> strOption (long "no-discover-test" <> help "Don't discover specified test import dependencies")
     ]
   optIncludeExternal2 <- switch (long "include-external" <> help "Include external import dependencies")
   pure CabalOptions2{..}
 
 runCabal2 :: CabalOptions2 -> IO ()
-runCabal2 = print
+runCabal2 CabalOptions2{..} = do
+  let discoverOpts = CabalDiscoverOpts
+        { toDiscover = fromMaybe (pure $ CabalDiscover (CabalLibraryUnit Nothing)) $ nonEmpty optToDiscover
+        , includeExternal = optIncludeExternal2
+        }
+  mg <- discoverCabalModuleGraph discoverOpts
+  BL.putStr $ encode $ toLookingGlass "Internal Package Dependencies" mempty mg
 
 runCabal :: CabalOptions -> IO ()
 runCabal CabalOptions{..} = do

--- a/app/Main/Cabal.hs
+++ b/app/Main/Cabal.hs
@@ -5,7 +5,7 @@ import           Data.Aeson           (encode)
 import           Data.Bool            (bool)
 import qualified Data.ByteString.Lazy as BL
 import           Data.List.NonEmpty   (NonEmpty (..), nonEmpty)
-import Data.Maybe (fromMaybe)
+import           Data.Maybe           (fromMaybe)
 import           Options.Applicative
 
 import           Graphex.Cabal
@@ -26,12 +26,12 @@ cabalOptions = do
   pure CabalOptions{..}
 
 data CabalOptions2 = CabalOptions2
-  { optToDiscover :: [CabalDiscoverType]
+  { optToDiscover       :: [CabalDiscoverType]
   , optIncludeExternal2 :: Bool
   } deriving stock Show
 
 justWhen :: a -> Bool -> Maybe a
-justWhen a True = Just a
+justWhen a True  = Just a
 justWhen _ False = Nothing
 
 cabalOptions2 :: Parser CabalOptions2

--- a/dummy-sublib/DummySublibModule.hs
+++ b/dummy-sublib/DummySublibModule.hs
@@ -1,0 +1,1 @@
+module DummySublibModule where

--- a/package.yaml
+++ b/package.yaml
@@ -34,6 +34,7 @@ dependencies:
 - directory
 - cassava
 - tree-view
+- semigroupoids
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -57,6 +57,10 @@ default-extensions:
   - LambdaCase
   - MultiWayIf
 
+internal-libraries:
+  graphex-dummy-sublib:
+    source-dirs: dummy-sublib
+
 executables:
   graphex:
     main:                Main.hs

--- a/src/Graphex/Cabal.hs
+++ b/src/Graphex/Cabal.hs
@@ -25,21 +25,31 @@ import           Data.Maybe                                    (maybeToList)
 import           Data.Semigroup.Foldable
 import qualified Data.Set                                      as Set
 import           Data.String                                   (fromString)
-import           System.Directory                              (doesFileExist, getDirectoryContents)
-import           System.FilePath                               (takeExtension, (<.>), (</>))
-import           UnliftIO.Async                                (pooledForConcurrently, pooledMapConcurrently)
+import           System.Directory                              (doesFileExist,
+                                                                getDirectoryContents)
+import           System.FilePath                               (takeExtension,
+                                                                (<.>), (</>))
+import           UnliftIO.Async                                (pooledForConcurrently,
+                                                                pooledMapConcurrently)
 
 -- Interface to cabal.
 
 import qualified Distribution.ModuleName                       as Cabal
-import           Distribution.PackageDescription               (BuildInfo (..), Executable (..), Library (..),
-                                                                PackageDescription (..), TestSuite (..),
-                                                                unUnqualComponentName, libraryNameString)
+import           Distribution.PackageDescription               (BuildInfo (..),
+                                                                Executable (..),
+                                                                Library (..),
+                                                                PackageDescription (..),
+                                                                TestSuite (..),
+                                                                libraryNameString,
+                                                                unUnqualComponentName)
 import           Distribution.PackageDescription.Configuration (flattenPackageDescription)
 import           Distribution.Verbosity                        (silent)
 
 #if MIN_VERSION_Cabal(3,6,0)
-import           Distribution.Utils.Path                       (PackageDir, SourceDir, SymbolicPath, getSymbolicPath)
+import           Distribution.Utils.Path                       (PackageDir,
+                                                                SourceDir,
+                                                                SymbolicPath,
+                                                                getSymbolicPath)
 #endif
 
 #if MIN_VERSION_Cabal(3,8,1)

--- a/src/Graphex/Logger.hs
+++ b/src/Graphex/Logger.hs
@@ -1,8 +1,8 @@
 module Graphex.Logger (logit) where
 
+import           Data.Functor       ((<&>))
 import           Debug.Trace        (traceM)
 import           System.Environment (lookupEnv)
-import Data.Functor ((<&>))
 
 data Verbosity =
     Silent

--- a/src/Graphex/Logger.hs
+++ b/src/Graphex/Logger.hs
@@ -1,0 +1,18 @@
+module Graphex.Logger (logit) where
+
+import           Debug.Trace        (traceM)
+import           System.Environment (lookupEnv)
+
+data Verbosity =
+    Silent
+  | Verbose
+
+verbosityFromEnv :: IO Verbosity
+verbosityFromEnv = lookupEnv "GRAPHEX_VERBOSITY" >>= \case
+  Nothing -> Silent
+  Just{} -> Verbose
+
+logit :: String -> IO ()
+logit str = verbosityFromEnv >>= \case
+  Silent -> pure ()
+  Verbose -> traceM str

--- a/src/Graphex/Logger.hs
+++ b/src/Graphex/Logger.hs
@@ -2,13 +2,14 @@ module Graphex.Logger (logit) where
 
 import           Debug.Trace        (traceM)
 import           System.Environment (lookupEnv)
+import Data.Functor ((<&>))
 
 data Verbosity =
     Silent
   | Verbose
 
 verbosityFromEnv :: IO Verbosity
-verbosityFromEnv = lookupEnv "GRAPHEX_VERBOSITY" >>= \case
+verbosityFromEnv = lookupEnv "GRAPHEX_VERBOSITY" <&> \case
   Nothing -> Silent
   Just{} -> Verbose
 

--- a/test/CabalSpec.hs
+++ b/test/CabalSpec.hs
@@ -43,12 +43,14 @@ exeModules =
   , Module "Main.Cabal" "app/Main/Cabal.hs"
   ]
 
+dummySublibModules :: [Module]
+dummySublibModules = [Module "DummySublibModule" "dummy-sublib/DummySublibModule.hs"]
 
 mkDiscoverCabalModulesUnit :: [Module] -> CabalDiscoverOpts -> IO ()
 mkDiscoverCabalModulesUnit (sort -> mods) opts = assertEqual "" mods . sort =<< discoverCabalModules opts "graphex.cabal"
 
 unit_libCabalModules :: IO ()
-unit_libCabalModules = mkDiscoverCabalModulesUnit libModules CabalDiscoverOpts
+unit_libCabalModules = mkDiscoverCabalModulesUnit (dummySublibModules ++ libModules) CabalDiscoverOpts
   { toDiscover = pure $ CabalDiscoverAll CabalLibrary
   , includeExternal = False
   }
@@ -62,6 +64,30 @@ unit_exeCabalModules = mkDiscoverCabalModulesUnit exeModules CabalDiscoverOpts
 unit_testCabalModules :: IO ()
 unit_testCabalModules = mkDiscoverCabalModulesUnit testModules CabalDiscoverOpts
   { toDiscover = pure $ CabalDiscoverAll CabalTests
+  , includeExternal = False
+  }
+
+unit_sublibCabalModules :: IO ()
+unit_sublibCabalModules = mkDiscoverCabalModulesUnit dummySublibModules CabalDiscoverOpts
+  { toDiscover = pure $ CabalDiscover (CabalLibraryUnit (Just "graphex-dummy-sublib"))
+  , includeExternal = False
+  }
+
+unit_defaultLibCabalModules :: IO ()
+unit_defaultLibCabalModules = mkDiscoverCabalModulesUnit libModules CabalDiscoverOpts
+  { toDiscover = pure $ CabalDiscover (CabalLibraryUnit Nothing)
+  , includeExternal = False
+  }
+
+unit_granularExeCabalModules :: IO ()
+unit_granularExeCabalModules = mkDiscoverCabalModulesUnit exeModules CabalDiscoverOpts
+  { toDiscover = pure $ CabalDiscover (CabalExecutableUnit "graphex")
+  , includeExternal = False
+  }
+
+unit_granularTestCabalModules :: IO ()
+unit_granularTestCabalModules = mkDiscoverCabalModulesUnit testModules CabalDiscoverOpts
+  { toDiscover = pure $ CabalDiscover (CabalTestsUnit "graphex-test")
   , includeExternal = False
   }
 

--- a/test/CabalSpec.hs
+++ b/test/CabalSpec.hs
@@ -24,6 +24,7 @@ libModules =
   , Module "Graphex.LookingGlass" "src/Graphex/LookingGlass.hs"
   , Module "Graphex.Parser" "src/Graphex/Parser.hs"
   , Module "Graphex.Search" "src/Graphex/Search.hs"
+  , Module "Graphex.Logger" "src/Graphex/Logger.hs"
   ]
 
 testModules :: [Module]
@@ -39,6 +40,7 @@ exeModules :: [Module]
 exeModules =
   [ Module "Paths_graphex" ModuleNoFile
   , Module "graphex-Main" "app/Main.hs"
+  , Module "Main.Cabal" "app/Main/Cabal.hs"
   ]
 
 
@@ -47,23 +49,23 @@ mkDiscoverCabalModulesUnit (sort -> mods) opts = assertEqual "" mods . sort =<< 
 
 unit_libCabalModules :: IO ()
 unit_libCabalModules = mkDiscoverCabalModulesUnit libModules CabalDiscoverOpts
-  { toDiscover = Set.singleton CabalLibraries
+  { toDiscover = pure $ CabalDiscoverAll CabalLibrary
   , includeExternal = False
   }
 
 unit_exeCabalModules :: IO ()
 unit_exeCabalModules = mkDiscoverCabalModulesUnit exeModules CabalDiscoverOpts
-  { toDiscover = Set.singleton CabalExecutables
+  { toDiscover = pure $ CabalDiscoverAll CabalExecutable
   , includeExternal = False
   }
 
 unit_testCabalModules :: IO ()
 unit_testCabalModules = mkDiscoverCabalModulesUnit testModules CabalDiscoverOpts
-  { toDiscover = Set.singleton CabalTests
+  { toDiscover = pure $ CabalDiscoverAll CabalTests
   , includeExternal = False
   }
 
 unit_discoverModules :: IO ()
 unit_discoverModules = do
-    g <- discoverCabalModuleGraph CabalDiscoverOpts{toDiscover = Set.singleton CabalLibraries, includeExternal = False}
+    g <- discoverCabalModuleGraph CabalDiscoverOpts{toDiscover = pure $ CabalDiscoverAll CabalLibrary, includeExternal = False}
     assertBool (show g) . isJust $ why g "Graphex.Parser" "Graphex.Core"


### PR DESCRIPTION
https://github.com/dustin/graphex/issues/28

```
$ graphex cabal --help
Usage: graphex cabal [--discover-all | --discover-all-libs | 
                       --discover-all-exes | --discover-all-tests | 
                       --no-discover-all-libs | --no-discover-all-exes | 
                       --no-discover-all-exes | --discover-lib | 
                       --no-discover-lib | --discover-sublib ARG | 
                       --no-discover-sublib ARG | --discover-exe ARG | 
                       --no-discover-exe ARG | --discover-test ARG | 
                       --no-discover-test ARG] [--include-external]

  Cabal operations

Available options:
  --discover-all           Discover all import dependencies
  --discover-all-libs      Discover all library import dependencies
  --discover-all-exes      Discover all executable import dependencies
  --discover-all-tests     Discover all test import dependencies
  --no-discover-all-libs   Discover no library import dependencies
  --no-discover-all-exes   Discover no executable import dependencies
  --no-discover-all-exes   Discover no test import dependencies
  --discover-lib           Discover the default library import dependencies
  --no-discover-lib        Don't discover the default library import
                           dependencies
  --discover-sublib ARG    Discover specified sublibrary import dependencies
  --no-discover-sublib ARG Don't discover specified sublibrary import
                           dependencies
  --discover-exe ARG       Discover specified executable import dependencies
  --no-discover-exe ARG    Don't discover specified executable import
                           dependencies
  --discover-test ARG      Discover specified test import dependencies
  --no-discover-test ARG   Don't discover specified test import dependencies
  --include-external       Include external import dependencies
  -h,--help                Show this help text
```

If you pass no `discover` args, it only discovers the main library.

If you do pass `discover` args, they are applied left-to-right. This makes for a nice CLI. For example:

```
# Discover all modules _except_ the graphex exe's
$ graphex cabal --discover-all --no-discover-exe graphex

# Discover everything except tests
$ graphex cabal --discover-all --no-discover-tests
```

I tested the new CLI on graphex and it seems to work. And the test suite for the logic is pretty solid.