### PR TITLE
graphex graph all regex support

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,7 @@ dependencies:
 - tree-view
 - unliftio
 - semigroupoids
+- regex-tdfa
 
 library:
   source-dirs: src

--- a/src/Graphex/Core.hs
+++ b/src/Graphex/Core.hs
@@ -33,6 +33,9 @@ setAttribute k attr val g@(Graph _ attrs) = g{attributes = Map.insertWith (<>) k
 getAttribute :: Ord a => a -> Text -> Graph a -> Maybe Text
 getAttribute nodeName aName = (Map.lookup aName <=< Map.lookup nodeName) . attributes
 
+graphNodes :: Graph a -> [a]
+graphNodes = Map.keys . unGraph
+
 -- Haskell
 data Import = Import
   { module_ :: ModuleName


### PR DESCRIPTION
Outputs all dependencies of all nodes that match a pattern.

The use-case I have for this is a module using [persistent-discover](https://hackage.haskell.org/package/persistent-discover). Graphex doesn't run pre-processors, so it thinks it has 0 deps. I can instead match on the module prefix I know all the discovered modules have.

Part of https://github.com/dustin/graphex/issues/36