### PR TITLE
Armando cabal imports of imported by

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 repl: graphex.cabal
-	cabal repl
+	cabal repl lib:graphex
 .PHONY: repl
 
 exe-repl: graphex.cabal

--- a/app/Main/Cabal.hs
+++ b/app/Main/Cabal.hs
@@ -1,12 +1,12 @@
 {-# LANGUAGE ApplicativeDo #-}
 module Main.Cabal where
 
+import           Control.Concurrent   (getNumCapabilities)
 import           Data.Aeson           (encode)
 import qualified Data.ByteString.Lazy as BL
 import           Data.List.NonEmpty   (nonEmpty)
 import           Data.Maybe           (fromMaybe)
 import           Options.Applicative
-import Control.Concurrent (getNumCapabilities)
 
 import           Graphex.Cabal
 import           Graphex.Core
@@ -16,8 +16,8 @@ import           Graphex.LookingGlass
 data CabalOptions = CabalOptions
   { optToDiscover      :: [CabalDiscoverType]
   , optIncludeExternal :: Bool
-  , optNumJobs :: Maybe Int
-  , optPruneTo :: [ModuleName]
+  , optNumJobs         :: Maybe Int
+  , optPruneTo         :: [ModuleName]
   } deriving stock Show
 
 justWhen :: a -> Bool -> Maybe a

--- a/package.yaml
+++ b/package.yaml
@@ -36,6 +36,7 @@ dependencies:
 - tree-view
 - unliftio
 - semigroupoids
+- stm
 
 library:
   source-dirs: src

--- a/src/Graphex/Queue.hs
+++ b/src/Graphex/Queue.hs
@@ -1,0 +1,22 @@
+module Graphex.Queue where
+
+-- | A functional queue.
+data Queue a = Queue [a] [a]
+
+qpop :: Queue a -> Maybe (a, Queue a)
+qpop (Queue (x:xs) r) = Just (x, if null xs then Queue (reverse r) [] else Queue xs r)
+qpop _                = Nothing
+
+qsingle :: a -> Queue a
+qsingle a = Queue [a] []
+
+qempty :: Queue a
+qempty = Queue [] []
+
+qlist :: [a] -> Queue a
+qlist xs = Queue xs []
+
+qappendList :: Queue a -> [a] -> Queue a
+qappendList (Queue [] []) xs = Queue xs []
+qappendList (Queue [] r) xs  = Queue (reverse r) (reverse xs)
+qappendList (Queue l r) xs   = Queue l (reverse xs <> r)

--- a/src/Graphex/Search.hs
+++ b/src/Graphex/Search.hs
@@ -2,11 +2,11 @@
 
 module Graphex.Search (bfsOn, bfsWith, dfsOn, dfsWith, findFirst, flood) where
 
-import           Data.List (find)
-import           Data.Set  (Set)
-import qualified Data.Set  as Set
+import           Data.List     (find)
+import           Data.Set      (Set)
+import qualified Data.Set      as Set
 
-import Graphex.Queue
+import           Graphex.Queue
 
 type SearchFunction r a = (a -> r) -> (a -> [a]) -> a -> [a]
 

--- a/src/Graphex/Search.hs
+++ b/src/Graphex/Search.hs
@@ -6,20 +6,7 @@ import           Data.List (find)
 import           Data.Set  (Set)
 import qualified Data.Set  as Set
 
--- | A functional queue.
-data Queue a = Queue [a] [a]
-
-qpop :: Queue a -> Maybe (a, Queue a)
-qpop (Queue (x:xs) r) = Just (x, if null xs then Queue (reverse r) [] else Queue xs r)
-qpop _                = Nothing
-
-qsingle :: a -> Queue a
-qsingle a = Queue [a] []
-
-qappendList :: Queue a -> [a] -> Queue  a
-qappendList (Queue [] []) xs = Queue xs []
-qappendList (Queue [] r) xs  = Queue (reverse r) (reverse xs)
-qappendList (Queue l r) xs   = Queue l (reverse xs <> r)
+import Graphex.Queue
 
 type SearchFunction r a = (a -> r) -> (a -> [a]) -> a -> [a]
 


### PR DESCRIPTION
Solves one part of #4 

Especially useful for big codebases and iteration - you can discover the subset of modules you care about when you're tuning a module's deps.

I also added a `--jobs` parameter. I apply it in the normal case as well. It was a little tricky to get right for the pruning version, but I verified there is parallelism with logging:
```
$ GRAPHEX_VERBOSITY=1 graphex cabal --prune-to Graphex
Discovering with num jobs =  8
Start parsing imports for Graphex
Finished parsing imports for Graphex
Start parsing imports for Graphex.Search
Start parsing imports for Graphex.LookingGlass
Start parsing imports for Graphex.Core
Finished parsing imports for Graphex.Search
Start parsing imports for Graphex.Queue
Finished parsing imports for Graphex.LookingGlass
Start parsing imports for Graphex.Core
Finished parsing imports for Graphex.Core
Finished parsing imports for Graphex.Queue
Finished parsing imports for Graphex.Core
{"attrs":{},"edges":[{"from":"Graphex","to":"Graphex.Core"},{"from":"Graphex","to":"Graphex.LookingGlass"},{"from":"Graphex","to":"Graphex.Search"},{"from":"Graphex.LookingGlass","to":"Graphex.Core"},{"from":"Graphex.Search","to":"Graphex.Queue"}],"nodes":{"Graphex":{"color":null,"label":"Graphex"},"Graphex.Core":{"color":null,"label":"Graphex.Core"},"Graphex.LookingGlass":{"color":null,"label":"Graphex.LookingGlass"},"Graphex.Queue":{"color":null,"label":"Graphex.Queue"},"Graphex.Search":{"color":null,"label":"Graphex.Search"}},"title":"Internal Package Dependencies"}
```

I didn't use it, but `Graphex.Queue` felt appropriate to be its own module.

I still need to update the tests / add more. I'm working to allow the user to provide regex(es) to discover as well.

I think the other direction of #4 can only be done with post-processing, so we have to discover the entire graph. Since we only have our imports in-hand but not who imports us, we have to parse everything.