### PR TITLE
graphex cabal --paths: Get a graph of filepaths

### DIFF
--- a/src/Graphex/Core.hs
+++ b/src/Graphex/Core.hs
@@ -49,6 +49,11 @@ newtype ModuleName = ModuleName { unModuleName :: Text }
 data ModulePath = ModuleNoFile | ModuleFile FilePath
   deriving stock (Eq, Ord, Show)
 
+moduleFilePath :: Module -> Maybe FilePath
+moduleFilePath Module{..} = case path of
+  ModuleNoFile  -> Nothing
+  ModuleFile fp -> Just fp
+
 instance IsString ModulePath where
   fromString = ModuleFile
 

--- a/src/Graphex/LookingGlass.hs
+++ b/src/Graphex/LookingGlass.hs
@@ -53,11 +53,11 @@ black = "black"
 
 toLookingGlass
   :: Text -- ^ title
-  -> Map ModuleName Color -- ^ Optionally re-color any nodes (black default)
-  -> ModuleGraph
+  -> Map Text Color -- ^ Optionally re-color any nodes (black default)
+  -> Graph Text
   -> GraphDef
 toLookingGlass title colors Graph{..} =
-  let mkNodeId (ModuleName m) = m
+  let mkNodeId m = m
       mkNode m =
         ( mkNodeId m
         , Node
@@ -68,6 +68,6 @@ toLookingGlass title colors Graph{..} =
   in GraphDef
      { nodes = Map.fromList $ fmap (\(m, _) -> mkNode m) $ Map.toList unGraph
      , edges = Map.toList unGraph >>= \(m, children) -> fmap (\c -> Edge{to = mkNodeId c, from = mkNodeId m}) $ Set.toList children
-     , attrs = Map.mapKeys unModuleName attributes
+     , attrs = attributes
      , ..
      }

--- a/test/CabalSpec.hs
+++ b/test/CabalSpec.hs
@@ -108,14 +108,14 @@ unit_granularTestCabalModules = mkDiscoverCabalModulesUnit testModules defaultOp
 
 unit_discoverModules :: IO ()
 unit_discoverModules = do
-    g <- discoverCabalModuleGraph defaultOpts{toDiscover = pure $ CabalDiscoverAll CabalLibrary, includeExternal = False}
-    assertBool (show g) . isJust $ why g "Graphex.Parser" "Graphex.Core"
+    CabalGraph{..} <- discoverCabalModuleGraph defaultOpts{toDiscover = pure $ CabalDiscoverAll CabalLibrary, includeExternal = False}
+    assertBool (show moduleGraph) . isJust $ why moduleGraph "Graphex.Parser" "Graphex.Core"
 
 unit_pruneToSearch :: IO ()
 unit_pruneToSearch = do
-  g <- discoverCabalModuleGraph defaultOpts
+  CabalGraph{..} <- discoverCabalModuleGraph defaultOpts
        { toDiscover = pure $ CabalDiscoverAll CabalLibrary
        , includeExternal = False
        , pruneTo = Just (== "Graphex.Search")
        }
-  assertEqual "" g searchModuleGraph
+  assertEqual "" moduleGraph searchModuleGraph

--- a/test/Spec.hs
+++ b/test/Spec.hs
@@ -231,10 +231,10 @@ unit_fromJSON = do
     -- TODO:  This graph is backwards
     assertBool (show g) . isJust $ why g "Graphex.Core" "Graphex"
 
-prop_lookingGlass :: ModuleGraph -> Property
+prop_lookingGlass :: Graph Text -> Property
 prop_lookingGlass g =  (not.null) (unGraph g) ==>
     counterexample (show lg) $
-    g === convertGraph ModuleName (depToGraph lg)
+    g === depToGraph lg
     where
         lg = toLookingGlass "Jabberwocky" (Map.fromList [("alpha", red), ("delta", black)]) g
 


### PR DESCRIPTION
This was a feature request. This will allow someone to do `graphex graph -r all` and get all reverse dependencies of a module in filepath form - which will allow them to then `touch` them to allow [ghciwatch](https://github.com/MercuryTechnologies/ghciwatch) to pick up on them.