### PR TITLE
Use Text instead of String in the import parser

### DIFF
--- a/src/Graphex/Parser.hs
+++ b/src/Graphex/Parser.hs
@@ -15,7 +15,9 @@ module Graphex.Parser where
 
 import           Data.Either          (rights)
 import           Data.String          (IsString)
+import           Data.Text            (Text)
 import qualified Data.Text            as T
+import qualified Data.Text.IO         as TIO
 import           Data.Void
 
 import           Replace.Megaparsec   (sepCap, streamEdit)
@@ -58,7 +60,7 @@ importsParser
   => m [Import]
 importsParser = rights <$> sepCap importParser
 
-removeBlockComments :: String -> String
+removeBlockComments :: Text -> Text
 removeBlockComments = streamEdit (blockCommentParser @Void) (\_ -> "")
 
 blockCommentParser
@@ -73,7 +75,7 @@ blockCommentParser = do
 
 parseFileImports :: FilePath -> IO [Import]
 parseFileImports fp = do
-  contents <- removeBlockComments <$> readFile fp
+  contents <- removeBlockComments <$> TIO.readFile fp
   case runParser (importsParser @Void) fp contents of
     Left err -> error $ unlines $ [mconcat ["Failed to parse ", fp, ":"], errorBundlePretty err]
     Right x -> pure x


### PR DESCRIPTION
Benchmarked `graphex cabal --discover-all` on a Large Codebase (Over 7k modules):

```
# String

real    0m38.949s
user    4m58.020s
sys     0m10.360s

real    0m38.888s
user    4m58.710s
sys     0m10.658s

# Text

real    0m29.197s
user    4m38.794s
sys     0m5.969s

real    0m29.396s
user    4m43.067s
sys     0m5.247s
```

Solid 25% or so speedup for free.